### PR TITLE
fix(release): align Docker publishing with semver tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,21 @@
-name: docker
+name: Docker
 
 on:
-  schedule:
-    - cron: '0 10 * * *' # everyday at 10am
   push:
     branches:
       - 'main'
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - 'main'
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+env:
+  IMAGE_NAME: wppconnect/server-cli
 
 jobs:
   docker:
@@ -19,44 +24,43 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            wppconnect/server-cli
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+      - name: Login to Docker Hub
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            wppconnect/server-cli:latest
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Publish npm and release
 
 on:
   push:
@@ -41,8 +41,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Validate release version
+        shell: bash
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          tag_version="${GITHUB_REF_NAME#v}"
+
+          if [[ "$package_version" != "$tag_version" ]]; then
+            echo "package.json version ($package_version) does not match tag ($GITHUB_REF_NAME)" >&2
+            exit 1
+          fi
+
+          if [[ ! "$package_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid semantic version: $package_version" >&2
+            exit 1
+          fi
+
+          echo "RELEASE_VERSION=$package_version" >> "$GITHUB_ENV"
+
       - name: Install Dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -51,26 +69,45 @@ jobs:
         run: yarn build
 
       - name: Publish in NPM
-        run: yarn publish --access public
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Generate Changelog
-        id: generate_changelog
+      - name: Generate release notes
+        shell: bash
         run: |
-          changelog=$(npm run changelog:last --silent)
-          changelog="${changelog//$'\n'/'%0A'}"
-          changelog="${changelog//$'\r'/'%0D'}" 
-          echo "changelog=${changelog-<empty>}" >> "$GITHUB_OUTPUT"
+          npm run changelog:last --silent > "$RUNNER_TEMP/release-notes.md"
+
+          if [[ ! -s "$RUNNER_TEMP/release-notes.md" ]]; then
+            echo "Release $GITHUB_REF_NAME" > "$RUNNER_TEMP/release-notes.md"
+          fi
 
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: ${{ steps.generate_changelog.outputs.changelog }}
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_args=(
+            "$GITHUB_REF_NAME"
+            --verify-tag
+            --title "$GITHUB_REF_NAME"
+            --notes-file "$RUNNER_TEMP/release-notes.md"
+          )
+
+          if [[ "$RELEASE_VERSION" == *-* ]]; then
+            release_args+=(--prerelease)
+          fi
+
+          gh release create "${release_args[@]}"
+
+      - name: Release summary
+        shell: bash
+        run: |
+          {
+            echo "### Published $GITHUB_REF_NAME"
+            echo "- npm: @wppconnect/server-cli@$RELEASE_VERSION"
+            echo "- Docker tags generated from the same Git tag:"
+            echo "  - wppconnect/server-cli:$GITHUB_REF_NAME"
+            echo "  - wppconnect/server-cli:$RELEASE_VERSION"
+            echo "  - wppconnect/server-cli:latest"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,22 @@ on:
         description: 'Tipo de incremento: patch, minor, major ou pre*'
         required: true
         default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+          - prerelease
 
 permissions:
-  contents: read
+  contents: write
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -18,6 +31,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: main
+          fetch-depth: 0
           token: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Setup GIT
@@ -44,7 +59,12 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+
+      - name: Build
+        run: yarn build
 
       - name: Release
-        run: 'npx release-it --increment ${{ github.event.inputs.increment }}'
+        run: yarn release-it --ci --increment ${{ inputs.increment }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:22.21.1-alpine AS base
+FROM node:22.22.2-alpine AS base
 WORKDIR /usr/src/wpp-server
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 # Install build dependencies and runtime libraries for sharp
 RUN apk update && \


### PR DESCRIPTION
## Summary
- align the Docker base image with the Node engine required by @wppconnect/server 2.10.1
- skip Puppeteer browser downloads with the current environment variable
- derive versioned Docker tags from v* release tags, matching wppconnect-server-go
- validate Git tag, package version, npm version, and GitHub Release version as one semver contract
- make the release increment an explicit semver choice

## Docker tags for v1.3.12
- v1.3.12
- 1.3.12
- 1.3
- 1
- sha-<commit>
- latest

## Validation
- yarn install and yarn build passed with Node 22.22.2
- actionlint passed for all changed workflows
- Prettier workflow checks passed
- git diff --check passed