### PR TITLE
fix(release): create GitHub release after Docker publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   IMAGE_NAME: wppconnect/server-cli
@@ -64,3 +64,32 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          DOCKER_TAGS: ${{ steps.meta.outputs.tags }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            echo "GitHub Release $GITHUB_REF_NAME already exists"
+            exit 0
+          fi
+
+          docker_release_notes="Docker image tags:
+          $(printf '%s\n' "$DOCKER_TAGS" | sed 's/^/- `/; s/$/`/')"
+
+          release_args=(
+            "$GITHUB_REF_NAME"
+            --verify-tag
+            --title "$GITHUB_REF_NAME"
+            --generate-notes
+            --notes "$docker_release_notes"
+          )
+
+          if [[ "${GITHUB_REF_NAME#v}" == *-* ]]; then
+            release_args+=(--prerelease)
+          fi
+
+          gh release create "${release_args[@]}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish npm and release
+name: Publish npm
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish:
@@ -72,42 +72,3 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Generate release notes
-        shell: bash
-        run: |
-          npm run changelog:last --silent > "$RUNNER_TEMP/release-notes.md"
-
-          if [[ ! -s "$RUNNER_TEMP/release-notes.md" ]]; then
-            echo "Release $GITHUB_REF_NAME" > "$RUNNER_TEMP/release-notes.md"
-          fi
-
-      - name: Create Release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          release_args=(
-            "$GITHUB_REF_NAME"
-            --verify-tag
-            --title "$GITHUB_REF_NAME"
-            --notes-file "$RUNNER_TEMP/release-notes.md"
-          )
-
-          if [[ "$RELEASE_VERSION" == *-* ]]; then
-            release_args+=(--prerelease)
-          fi
-
-          gh release create "${release_args[@]}"
-
-      - name: Release summary
-        shell: bash
-        run: |
-          {
-            echo "### Published $GITHUB_REF_NAME"
-            echo "- npm: @wppconnect/server-cli@$RELEASE_VERSION"
-            echo "- Docker tags generated from the same Git tag:"
-            echo "  - wppconnect/server-cli:$GITHUB_REF_NAME"
-            echo "  - wppconnect/server-cli:$RELEASE_VERSION"
-            echo "  - wppconnect/server-cli:latest"
-          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- create GitHub Releases only after the versioned Docker image is pushed successfully
- include the exact Docker tags generated by metadata-action in the release notes
- keep npm publication independent so registry credential failures do not block Docker releases
- make release creation idempotent for workflow reruns

## Context
The v1.3.12 npm publication reached the registry with the correct package/version but the repository NPM_TOKEN was rejected with E404. Docker publishing remains the source of truth requested for GitHub Releases.

## Validation
- actionlint passed
- Prettier checks passed
- git diff --check passed