### PR TITLE
fix(ci): publish npm package with trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - 'v*'
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -23,10 +24,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22.22.2
+          node-version: 24.18.1
           registry-url: 'https://registry.npmjs.org'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Get yarn cache directory
         id: yarn-cache
@@ -63,12 +62,9 @@ jobs:
         run: yarn install --frozen-lockfile
         env:
           PUPPETEER_SKIP_DOWNLOAD: true
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build
         run: yarn build
 
       - name: Publish in NPM
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.13",
   "description": "Servidor de WPPConnect com frontend para ser executado a partir de uma linha de comando",
   "bin": {
-    "wppserver": "./bin/wppserver.js"
+    "wppserver": "bin/wppserver.js"
   },
   "main": "dist/index.js",
   "author": "edgardmessias",
@@ -17,7 +17,7 @@
     "license:add": "license-check-and-add add",
     "license:check": "license-check-and-add check",
     "lint": "eslint --ext .js src",
-    "prepare": "husky install",
+    "prepare": "husky",
     "release": "release-it",
     "start": "cross-env RUN_SERVER=1 babel-node src",
     "watch": "nodemon -w src --exec \"babel-node src\""


### PR DESCRIPTION
## Summary
- publish `@wppconnect/server-cli` through npm Trusted Publishing (OIDC)
- remove the invalid long-lived `NPM_TOKEN` dependency
- use the same Node version as the working `wppconnect` publisher
- remove the Husky 9 and npm package metadata warnings

## npm Trusted Publisher
The npm package must trust:
- Organization: `wppconnect-team`
- Repository: `server-cli`
- Workflow: `publish.yml`
- Allowed action: `npm publish`

## Validation
- `yarn build`
- `npm pack --dry-run --json`
- workflow YAML parse
- `git diff --check`

`yarn lint` still reports the repository's pre-existing CRLF-only formatting errors in `src/index.js` and `src/program.js`; neither file is changed by this PR.