### PR TITLE
fix(ci): keep Node 22 for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24.18.1
+          node-version: 22.22.2
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install --global npm@12.0.2
 
       - name: Get yarn cache directory
         id: yarn-cache
@@ -33,7 +36,7 @@ jobs:
           echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Setup yarn cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## Summary
- keep Node `22.22.2`, required exactly by `@wppconnect/server@2.10.1`
- install npm `12.0.2`, which supports Trusted Publishing and Node `22.22.2`
- update `actions/cache` to v5 to remove the Node 20 action runtime warning

## Root cause of v1.3.14 failure
The OIDC workflow reached dependency installation, but Yarn rejected Node `24.18.1` because `@wppconnect/server` declares an exact Node `22.22.2` engine.

## Validation
- workflow YAML assertions
- confirmed npm `12.0.2` engines: `^22.22.2 || ^24.15.0 || >=26.0.0`
- executed Node `22.22.2`
- `npm pack --dry-run --json`
- `git diff --check`