### PR TITLE
fix(ci): run npm trusted publisher in isolation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,8 @@ jobs:
           node-version: 22.22.2
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm for trusted publishing
-        run: npm install --global npm@12.0.2
+      - name: Verify npm for trusted publishing
+        run: npx --yes npm@12.0.2 --version
 
       - name: Get yarn cache directory
         id: yarn-cache
@@ -70,4 +70,4 @@ jobs:
         run: yarn build
 
       - name: Publish in NPM
-        run: npm publish --access public
+        run: npx --yes npm@12.0.2 publish --access public


### PR DESCRIPTION
## Summary
- run npm `12.0.2` through `npx` instead of replacing the runner's global npm in place
- keep Node `22.22.2` for the exact engine required by `@wppconnect/server`
- use the isolated npm 12 CLI for the OIDC publish operation

## Root cause of v1.3.15 failure
`npm install --global npm@12.0.2` replaced npm's own dependency tree while npm was still executing, then failed with `Cannot find module 'promise-retry'`.

## Validation
- isolated `npx --yes npm@12.0.2 --version` => `12.0.2`
- isolated npm 12 package dry run
- workflow YAML assertions
- `git diff --check`