### PR TITLE
fix(package): declare repository for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@wppconnect/server-cli",
   "version": "1.3.16",
   "description": "Servidor de WPPConnect com frontend para ser executado a partir de uma linha de comando",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wppconnect-team/server-cli"
+  },
   "bin": {
     "wppserver": "bin/wppserver.js"
   },


### PR DESCRIPTION
## Summary
- declare `repository.url` as `https://github.com/wppconnect-team/server-cli`
- allow npm Trusted Publishing to validate the package against the GitHub provenance bundle

## Root cause
The authorized OIDC publish signed and uploaded its Sigstore provenance, but npm rejected it with `E422` because `package.json` did not contain `repository.url`.

## Validation
- source manifest assertion for the exact repository URL
- package build
- npm 12 real tarball inspection: packed `package/package.json` contains the exact expected URL
- `git diff --check`