### PR TITLE
fix(ci): attribute releases to joaosouz4dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Setup GIT
         if: steps.release-check.outputs.should_release == 'true'
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "joaosouz4dev"
+          git config --global user.email "47183663+joaosouz4dev@users.noreply.github.com"
 
       - name: Setup Node
         if: steps.release-check.outputs.should_release == 'true'


### PR DESCRIPTION
## Summary
- configure release commits and annotated tags as `joaosouz4dev`
- use the GitHub noreply address associated with account ID `47183663`

## Root cause
The workflow pushed release commits and tags using the repository secret `PERSONAL_TOKEN`. That secret belonged to `icleitoncosta`, so GitHub correctly displayed `icleitoncosta pushed` even though the Git author was `github-actions[bot]`.

The repository secret was rotated separately to the currently authenticated `joaosouz4dev` credential without exposing its value.

## Validation
- workflow YAML parse
- release identity assertions
- `git diff --check`